### PR TITLE
建物のポップアップを編集、一部にリンクの追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,29 +54,64 @@
     const Bldg1 = L.polygon([[1193,1727],[935,1727],[935,2082],[1193,2082]],{
       color: 'transparent', 
       fillOpacity: 0, 
-    }).addTo(map);
+    }).addTo(map).bindPopup(`
+    <div style="text-align:center;">
+      <p><b>1号館</b></p>
+      <a href="./assets/1号館.svg" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
 
     const Bldg101 = L.polygon([[1181,2177],[1181,2423],[1115,2423],[1115,2177]],{
       color: 'transparent', 
       fillOpacity: 0, 
-    }).addTo(map);
+    }).addTo(map).bindPopup(`
+    <div style="text-align:center;">
+      <p><b>101号館</b></p>
+      <a href="path" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
 
     const Bldg2 = L.polygon([[964,1017],[879,1017],[879,1173],[964,1173]],{
       color: 'transparent', 
       fillOpacity: 0, 
-    }).addTo(map);
+    }).addTo(map).bindPopup(`
+    <div style="text-align:center;">
+      <p><b>2号館</b></p>
+      <a href="path" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
 
     const bldg5 = L.polygon([[1612,1352],[1506,1353],[1505,1625],[1613,1624]],{
       color: 'transparent', //枠線の色を透明に
       fillOpacity: 0, //塗りの透明度を0に
     }).addTo(map)
-    .bindPopup()
+    .bindPopup(`
+    <div style="text-align:center;">
+      <p><b>5号館</b></p>
+      <a href="./assets/5号館.svg" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
 
     const bldg7 = L.polygon([[1461,1557],[1342,1558],[1341,1733],[1461,1732]],{
       color: 'transparent', //枠線の色を透明に
       fillOpacity: 0, //塗りの透明度を0に
     }).addTo(map)
-    .bindPopup()
+    .bindPopup(`
+    <div style="text-align:center;">
+      <p><b>7号館</b></p>
+      <a href="./assets/7号館.svg" target="_blank">
+        階層図
+      </a>
+    </div>
+    `)
 
     const Bldg8 = L.polygon([[1438,1941],[1438,2205],[1349,2205],[1349,1941]],{
       color: 'transparent', //枠線の色を透明に
@@ -84,9 +119,9 @@
     }).addTo(map)
     .bindPopup(`
     <div style="text-align:center;">
-      <p><b>図書館</b></p>
+      <p><b>8号館</b></p>
       <a href="path" target="_blank">
-        <img src="path" alt="図書館構造図" width="120" />
+        階層図
       </a>
     </div>
     `)
@@ -97,9 +132,9 @@
     }).addTo(map)
     .bindPopup(`
     <div style="text-align:center;">
-      <p><b>図書館</b></p>
+      <p><b>9号館</b></p>
       <a href="path" target="_blank">
-        <img src="path" alt="図書館構造図" width="120" />
+        階層図
       </a>
     </div>
     `)
@@ -110,9 +145,9 @@
     }).addTo(map)
     .bindPopup(`
     <div style="text-align:center;">
-      <p><b>図書館</b></p>
+      <p><b>10号館</b></p>
       <a href="path" target="_blank">
-        <img src="path" alt="図書館構造図" width="120" />
+        階層図
       </a>
     </div>
     `)
@@ -120,28 +155,63 @@
   const Bldg11 = L.polygon([[1194,1510],[1194,1624],[1015,1624],[1015,1510]],{
       color: 'transparent', 
       fillOpacity: 0, 
-    }).addTo(map);
+    }).addTo(map).bindPopup(`
+    <div style="text-align:center;">
+      <p><b>11号館</b></p>
+      <a href="path" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
 
     const Bldg12 = L.polygon([[1086,1210],[1086,1325],[948,1325],[948,1210]],{
       color: 'transparent', 
       fillOpacity: 0, 
-    }).addTo(map);
+    }).addTo(map).bindPopup(`
+    <div style="text-align:center;">
+      <p><b>12号館</b></p>
+      <a href="./assets/12号館.svg" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
 
     const Bldg13 = L.polygon([[1217,1209],[1217,1420],[1121,1420],[1121,1209]],{
       color: 'transparent', 
       fillOpacity: 0, 
-    }).addTo(map);
+    }).addTo(map).bindPopup(`
+    <div style="text-align:center;">
+      <p><b>13号館</b></p>
+      <a href="path" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
 
     const Bldg14 = L.polygon([[1222,992],[1215,1155],[1126,1155],[1126,1057],[1018,1057],[1018,989]],{
       color: 'transparent', 
       fillOpacity: 0, 
-    }).addTo(map);
+    }).addTo(map).bindPopup(`
+    <div style="text-align:center;">
+      <p><b>14号館</b></p>
+      <a href="path" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
 
     const bldg17 = L.polygon([[1589,1136],[1487,1136],[1486,1308],[1588,1308]],{
       color: 'transparent', //枠線の色を透明に
       fillOpacity: 0, //塗りの透明度を0に
     }).addTo(map)
-    .bindPopup()
+    .bindPopup(`
+    <div style="text-align:center;">
+      <p><b>17号館</b></p>
+      <a href="path" target="_blank">
+        階層図
+      </a>
+    </div>
+    `)
 
     const Bldg18 = L.polygon([[1763,1718],[1763,1913],[1665,1913],[1665,1823],[1523,1818],[1519,1720]],{
       color: 'transparent', //枠線の色を透明に
@@ -149,9 +219,9 @@
     }).addTo(map)
     .bindPopup(`
     <div style="text-align:center;">
-      <p><b>図書館</b></p>
+      <p><b>18号館</b></p>
       <a href="path" target="_blank">
-        <img src="path" alt="図書館構造図" width="120" />
+        階層図
       </a>
     </div>
     `)
@@ -162,9 +232,9 @@
     }).addTo(map)
     .bindPopup(`
     <div style="text-align:center;">
-      <p><b>図書館</b></p>
+      <p><b>19号館</b></p>
       <a href="path" target="_blank">
-        <img src="path" alt="図書館構造図" width="120" />
+        階層図
       </a>
     </div>
     `)
@@ -175,9 +245,9 @@
     }).addTo(map)
     .bindPopup(`
     <div style="text-align:center;">
-      <p><b>図書館</b></p>
+      <p><b>21KOMCEE West</b></p>
       <a href="path" target="_blank">
-        <img src="path" alt="図書館構造図" width="120" />
+        階層図
       </a>
     </div>
     `)
@@ -188,9 +258,9 @@
     }).addTo(map)
     .bindPopup(`
     <div style="text-align:center;">
-      <p><b>図書館</b></p>
+      <p><b>21KOMCEE East</b></p>
       <a href="path" target="_blank">
-        <img src="path" alt="図書館構造図" width="120" />
+        階層図
       </a>
     </div>
     `);
@@ -198,12 +268,26 @@
     const ClassRoom900 = L.polygon([[860,1373],[763,1373],[763,1493],[739,1493],[739,1558],[877,1558],[877,1494],[860,1494]],{
       color: 'transparent', 
       fillOpacity: 0, 
-    }).addTo(map);
+    }).addTo(map).bindPopup(`
+    <div style="text-align:center;">
+      <p><b>900番講堂</b></p>
+      <a href="path" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
 
     const InfoEduBuild = L.polygon([[482,1434],[381,1434],[381,1772],[482,1772]],{
       color: 'transparent', 
       fillOpacity: 0, 
-    }).addTo(map);
+    }).addTo(map).bindPopup(`
+    <div style="text-align:center;">
+      <p><b>情報教育棟</b></p>
+      <a href="path" target="_blank">
+        階層図
+      </a>
+    </div>
+    `);
   </script>
 </body>
 </html>


### PR DESCRIPTION
建物内のポップアップの内容を<p><b>建物名</b></p><a href="path">階層図</a>に変更した。
1，5，7，12号館にはリンクに./assets/x号館.svgでパスを指定した。